### PR TITLE
Added support for service account usage

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -48,16 +48,24 @@ class CustomStacIO(DefaultStacIO):
 
     def __init__(self):
         self.session = botocore.session.Session()
-        self.s3_client = self.session.create_client(
-            service_name="s3",
-            region_name=os.environ.get("AWS_REGION"),
-            endpoint_url=os.environ.get("AWS_S3_ENDPOINT"),
-            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
-            verify=True,
-            use_ssl=True,
-            config=Config(s3={"addressing_style": "path", "signature_version": "s3v4"}),
-        )
+        if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
+            self.s3_client = self.session.create_client(
+                service_name="s3",
+                region_name=os.environ.get("AWS_REGION"),
+                endpoint_url=os.environ.get("AWS_S3_ENDPOINT"),
+                aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+                aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+                verify=True,
+                use_ssl=True,
+                config=Config(s3={"addressing_style": "path", "signature_version": "s3v4"}),
+            )
+        else:
+            self.s3_client = self.session.create_client(
+                service_name="s3",
+                verify=True,
+                use_ssl=True,
+                config=Config(s3={"addressing_style": "path", "signature_version": "s3v4"}),
+            )
 
     def read_text(self, source, *args, **kwargs):
         parsed = urlparse(source)

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -48,6 +48,9 @@ class CustomStacIO(DefaultStacIO):
 
     def __init__(self):
         self.session = botocore.session.Session()
+        # Two pathways provided here to support authorisation via:
+        # 1) AWS credentials, when keys are provided as environment variables or,
+        # 2) Service Account, when AWS credentials are not provided as environment variables
         if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
             self.s3_client = self.session.create_client(
                 service_name="s3",


### PR DESCRIPTION
Updated service.py to support S3 access via service account, rather than relying on pre-defined AWS credentials. This will address the 'empty results being returned' issue.