### PR TITLE
Remove STAGEIN_WORKSPACE parameter as no longer needed

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -183,7 +183,6 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             self.conf["additional_parameters"]["collection_id"] = lenv.get("usid", "")
             self.conf["additional_parameters"]["process"] = "processing-results"
             self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"] = self.workspace_name
-            self.conf["additional_parameters"]["STAGEIN_WORKSPACE"] = self.workspace_name
 
         except Exception as e:
             logger.error("ERROR in pre_execution_hook...")
@@ -310,7 +309,6 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         conf["additional_parameters"]["STAGEIN_AWS_ACCESS_KEY_ID"] = os.environ.get("STAGEIN_AWS_ACCESS_KEY_ID", "minio-admin")
         conf["additional_parameters"]["STAGEIN_AWS_SECRET_ACCESS_KEY"] = os.environ.get("STAGEIN_AWS_SECRET_ACCESS_KEY", "minio-secret-password")
         conf["additional_parameters"]["STAGEIN_AWS_REGION"] = os.environ.get("STAGEIN_AWS_REGION", "RegionOne")
-        conf["additional_parameters"]["STAGEIN_WORKSPACE"] = os.environ.get("STAGEIN_WORKSPACE", "default")
 
         conf["additional_parameters"]["STAGEOUT_AWS_SERVICEURL"] = os.environ.get("STAGEOUT_AWS_SERVICEURL", "http://s3-service.zoo.svc.cluster.local:9000")
         conf["additional_parameters"]["STAGEOUT_AWS_ACCESS_KEY_ID"] = os.environ.get("STAGEOUT_AWS_ACCESS_KEY_ID", "minio-admin")


### PR DESCRIPTION
## Remove STAGEIN_WORKSPACE Parameter
This parameter is no longer needed by the stagein script, as access to workspace data is instead provided by mounting the required volumes to the running pod.