### PR TITLE
EODHP-827 display https links in workflow results

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -1,6 +1,5 @@
 # see https://zoo-project.github.io/workshops/2014/first_service.html#f1
 import pathlib
-import time
 
 try:
     import zoo
@@ -226,9 +225,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 s3_path = output["StacCatalogUri"]
                 if s3_path.count("s3://")==0:
                     s3_path = "s3://" + s3_path
-                cat = read_file( s3_path )
-                logger.info(cat)
-                logger.info(cat.links)
+                cat = read_file(s3_path)
             except Exception as e:
                 logger.error(f"Exception: {e}")
 
@@ -236,14 +233,11 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             logger.info(f"Create collection with ID {collection_id}")
             collection = None
             try:
-                logger.info("Try to get collection from outputs")
                 collection = next(cat.get_all_collections())
-                logger.info(collection)
-                logger.info(collection.links)
                 logger.info("Got collection from outputs")
-            except Exception as e1:
-                logger.error(f"Exception1: {e1}"+str(e1))
+            except:
                 try:
+                    logger.info("No collection found in outputs, creating from items")
                     items=cat.get_all_items()
                     itemFinal=[]
                     for i in items:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -216,17 +216,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 s3_path = output["StacCatalogUri"]
                 if s3_path.count("s3://")==0:
                     s3_path = "s3://" + s3_path
-                #cat = read_file( s3_path )
-                # Construct Resource Catalogue link
-                rc_path = f'https://dev.eodatahub.org.uk/api/catalogue/stac/catalogs/user-datasets/"{self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"]}/{self.conf["additional_parameters"]["process"]}/cat_{self.conf["additional_parameters"]["collection_id"]}'
-                try:
-                    cat = read_file(rc_path)
-                except:
-                    time.sleep(10)
-                    try:
-                        cat = read_file(rc_path)
-                    except:
-                        cat = read_file( s3_path )
+                cat = read_file( s3_path )
                 logger.info(cat)
                 logger.info(cat.links)
             except Exception as e:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -216,6 +216,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 if s3_path.count("s3://")==0:
                     s3_path = "s3://" + s3_path
                 cat = read_file( s3_path )
+                logger.info(cat)
             except Exception as e:
                 logger.error(f"Exception: {e}")
 
@@ -223,6 +224,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             logger.info(f"Create collection with ID {collection_id}")
             collection = None
             try:
+                logger.ingo("Try to get collection from outputs")
                 collection = next(cat.get_all_collections())
                 logger.info("Got collection from outputs")
             except:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -265,11 +265,11 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             bucket = self.conf["additional_parameters"]["STAGEOUT_OUTPUT"]
             workspace = self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"]
             subfolder = self.conf["additional_parameters"]["process"]
-            logger.info("workspace domain is " + workspace_domain)
             if workspace_domain:
                 for link in collection_dict["links"]:
                     if "href" in link:
-                        link["href"] = link["href"].replace(f"s3://{bucket}/{os.path.join(workspace, subfolder)}", f"https://{workspace}.{workspace_domain}/files/{bucket}/{subfolder}")
+                        link["href"] = link["href"].replace(f"s3://{bucket}/{os.path.join(workspace, subfolder)}", 
+                                                            f"https://{workspace}.{workspace_domain}/files/{bucket}/{subfolder}")
                         logger.info("Updated link href to " + link["href"])
 
             # Set the feature collection to be returned

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -79,7 +79,7 @@ class CustomStacIO(DefaultStacIO):
             # URL is a http path to a workspace file, get directly from s3
             parts = parsed.path.split("/", 3)
             return (
-                self.s3_client.get_object(Bucket=parts[2], Key=parts[3])[
+                self.s3_client.get_object(Bucket=parts[2], Key=f"{parsed.netloc.split('.')[0]}/{parts[3]}")[
                     "Body"
                 ]
                 .read()
@@ -241,7 +241,8 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 logger.info(collection)
                 logger.info(collection.links)
                 logger.info("Got collection from outputs")
-            except:
+            except Exception as e1:
+                logger.error(f"Exception1: {e1}"+str(e1))
                 try:
                     items=cat.get_all_items()
                     itemFinal=[]

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -265,12 +265,12 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             bucket = self.conf["additional_parameters"]["STAGEOUT_OUTPUT"]
             workspace = self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"]
             subfolder = self.conf["additional_parameters"]["process"]
-            print("workspace domain is " + workspace_domain)
+            logger.info("workspace domain is " + workspace_domain)
             if workspace_domain:
                 for link in collection_dict["links"]:
                     if "href" in link:
                         link["href"] = link["href"].replace(f"s3://{bucket}/{os.path.join(workspace, subfolder)}", f"https://{workspace}/{workspace_domain}/files/{bucket}/{subfolder}")
-                        print("Updated link href to " + link["href"])
+                        logger.info("Updated link href to " + link["href"])
 
             # Set the feature collection to be returned
             self.feature_collection = json.dumps(collection_dict, indent=2)

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -217,6 +217,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     s3_path = "s3://" + s3_path
                 cat = read_file( s3_path )
                 logger.info(cat)
+                logger.info(cat.links)
             except Exception as e:
                 logger.error(f"Exception: {e}")
 
@@ -224,7 +225,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             logger.info(f"Create collection with ID {collection_id}")
             collection = None
             try:
-                logger.ingo("Try to get collection from outputs")
+                logger.info("Try to get collection from outputs")
                 collection = next(cat.get_all_collections())
                 logger.info("Got collection from outputs")
             except:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -258,7 +258,19 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 return
 
             collection_dict=collection.to_dict()
-            collection_dict["id"]=collection_id
+            collection_dict["id"]=f"col_{collection_id}"
+
+            # Update links with HTTPS links
+            workspace_domain = self.conf["additional_parameters"]["WORKSPACE_DOMAIN"]
+            bucket = self.conf["additional_parameters"]["STAGEOUT_OUTPUT"]
+            workspace = self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"]
+            subfolder = self.conf["additional_parameters"]["process"]
+            print("workspace domain is " + workspace_domain)
+            if workspace_domain:
+                for link in collection_dict["links"]:
+                    if "href" in link:
+                        link["href"] = link["href"].replace(f"s3://{bucket}/{os.path.join(workspace, subfolder)}", f"https://{workspace}/{workspace_domain}/files/{bucket}/{subfolder}")
+                        print("Updated link href to " + link["href"])
 
             # Set the feature collection to be returned
             self.feature_collection = json.dumps(collection_dict, indent=2)

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -1,5 +1,6 @@
 # see https://zoo-project.github.io/workshops/2014/first_service.html#f1
 import pathlib
+import time
 
 try:
     import zoo
@@ -215,7 +216,17 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 s3_path = output["StacCatalogUri"]
                 if s3_path.count("s3://")==0:
                     s3_path = "s3://" + s3_path
-                cat = read_file( s3_path )
+                #cat = read_file( s3_path )
+                # Construct Resource Catalogue link
+                rc_path = f'https://dev.eodatahub.org.uk/api/catalogue/stac/catalogs/user-datasets/"{self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"]}/{self.conf["additional_parameters"]["process"]}/cat_{self.conf["additional_parameters"]["collection_id"]}'
+                try:
+                    cat = read_file(rc_path)
+                except:
+                    time.sleep(10)
+                    try:
+                        cat = read_file(rc_path)
+                    except:
+                        cat = read_file( s3_path )
                 logger.info(cat)
                 logger.info(cat.links)
             except Exception as e:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -228,6 +228,8 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             try:
                 logger.info("Try to get collection from outputs")
                 collection = next(cat.get_all_collections())
+                logger.info(collection)
+                logger.info(collection.links)
                 logger.info("Got collection from outputs")
             except:
                 try:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -269,7 +269,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             if workspace_domain:
                 for link in collection_dict["links"]:
                     if "href" in link:
-                        link["href"] = link["href"].replace(f"s3://{bucket}/{os.path.join(workspace, subfolder)}", f"https://{workspace}/{workspace_domain}/files/{bucket}/{subfolder}")
+                        link["href"] = link["href"].replace(f"s3://{bucket}/{os.path.join(workspace, subfolder)}", f"https://{workspace}.{workspace_domain}/files/{bucket}/{subfolder}")
                         logger.info("Updated link href to " + link["href"])
 
             # Set the feature collection to be returned


### PR DESCRIPTION
Files from stageout may now contain links that are https links to s3 files. These are decoded into bucket and key to obtain from s3 directly, so that the whole collection with https links may be returned