### PR TITLE
Feature/eodhp 1090 workflow results placed in workflow catalogs

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -128,6 +128,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         else:
             self.use_workspace = False
         self.workspace_name = self.inputs.get("workspace", {}).get("value", "default")
+        self.executing_workspace_name = self.inputs.get("executing_workspace", {}).get("value", "default")
 
         auth_env = self.conf.get("auth_env", {})
         self.ades_rx_token = auth_env.get("jwt", "")
@@ -189,7 +190,10 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             else:
                 logger.info("Using pre-configured storage details")
 
-            output_prefix = "processing-results/{{cookiecutter.workflow_id}}"
+            if self.executing_workspace_name in ["airbus", "planet"]:
+                output_prefix = f"commercial-data/{self.executing_workspace_name}/{{cookiecutter.workflow_id}}"
+            else:
+                output_prefix = "processing-results/{{cookiecutter.workflow_id}}"
 
             lenv = self.conf.get("lenv", {})
             self.conf["additional_parameters"]["job_id"] = lenv.get("usid", "")

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -189,9 +189,11 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             else:
                 logger.info("Using pre-configured storage details")
 
+            output_prefix = "processing-results/{{cookiecutter.workflow_id}}"
+
             lenv = self.conf.get("lenv", {})
             self.conf["additional_parameters"]["job_id"] = lenv.get("usid", "")
-            self.conf["additional_parameters"]["process"] = "processing-results"
+            self.conf["additional_parameters"]["process"] = output_prefix
             self.conf["additional_parameters"]["STAGEOUT_WORKSPACE"] = self.workspace_name
             self.conf["additional_parameters"]["workflow_id"] = "{{cookiecutter.workflow_id}}"
 

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -191,7 +191,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 logger.info("Using pre-configured storage details")
 
             if self.executing_workspace_name in ["airbus", "planet"]:
-                output_prefix = f"commercial-data/{self.executing_workspace_name}/{{cookiecutter.workflow_id}}"
+                output_prefix = f"commercial-data/{self.executing_workspace_name}"
             else:
                 output_prefix = "processing-results/{{cookiecutter.workflow_id}}"
 


### PR DESCRIPTION
## Generate subfolder path to give result details
- If the workflow being run is for a data adapter (`airbus` or `planet` data) generate a new path prefix: `commercial-data/<adapter>` 
- Otherwise, generate a new path prefix which identifies the workflow ID that generated the contained datasets: `processing-results/<workflow-id>`