### PR TITLE
Bugfix/avoid logs getting mixed up

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -525,13 +525,13 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         exit_status = runner.execute()
 
         # Set job_id
-        job_id = conf["lenv"]["usid"]
+        # job_id = conf["lenv"]["usid"]
 
-        # Create a CoreV1Api client instance
-        v1 = client.CoreV1Api()
+        # # Create a CoreV1Api client instance
+        # v1 = client.CoreV1Api()
 
-        # Delete params configmap
-        params_cm_name = f"params-{job_id}"
+        # # Delete params configmap
+        # params_cm_name = f"params-{job_id}"
 
         # Delete the ConfigMap
         # try:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -528,35 +528,35 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         job_id = conf["lenv"]["usid"]
 
         # Create a CoreV1Api client instance
-        v1 = client.CoreV1Api()
+        # v1 = client.CoreV1Api()
 
-        # Delete params configmap
-        params_cm_name = f"params-{job_id}"
+        # # Delete params configmap
+        # params_cm_name = f"params-{job_id}"
 
-        # Delete the ConfigMap
-        try:
-            v1.delete_namespaced_configmap(
-                name=params_cm_name,
-                namespace=executing_namespace,
-                body=client.V1DeleteOptions(),
-            )
-            logger.info(f"ConfigMap {params_cm_name} deleted successfully")
-        except client.exceptions.ApiException as e:
-            logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
+        # # Delete the ConfigMap
+        # try:
+        #     v1.delete_namespaced_configmap(
+        #         name=params_cm_name,
+        #         namespace=executing_namespace,
+        #         body=client.V1DeleteOptions(),
+        #     )
+        #     logger.info(f"ConfigMap {params_cm_name} deleted successfully")
+        # except client.exceptions.ApiException as e:
+        #     logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
 
-        # Delete cwl-workflow configmap
-        cwl_cm_name = f"cwl-workflow-{job_id}"
+        # # Delete cwl-workflow configmap
+        # cwl_cm_name = f"cwl-workflow-{job_id}"
 
-        # Delete the ConfigMap
-        try:
-            v1.delete_namespaced_configmap(
-                name=cwl_cm_name,
-                namespace=executing_namespace,
-                body=client.V1DeleteOptions(),
-            )
-            logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
-        except client.exceptions.ApiException as e:
-            logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
+        # # Delete the ConfigMap
+        # try:
+        #     v1.delete_namespaced_configmap(
+        #         name=cwl_cm_name,
+        #         namespace=executing_namespace,
+        #         body=client.V1DeleteOptions(),
+        #     )
+        #     logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
+        # except client.exceptions.ApiException as e:
+        #     logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
 
 
         if exit_status == zoo.SERVICE_SUCCEEDED:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -496,6 +496,8 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         conf.setdefault("eodhp", {})
         conf["eodhp"]["serviceAccountName"] = "default"
 
+        logger.info(f"CONF IS NOW {conf}")
+
         execution_handler = EoepcaCalrissianRunnerExecutionHandler(conf=conf, inputs=inputs)
 
         runner = ZooCalrissianRunner(

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -533,30 +533,30 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         # Delete params configmap
         params_cm_name = f"params-{job_id}"
 
-        # # Delete the ConfigMap
-        # try:
-        #     v1.delete_namespaced_config_map(
-        #         name=params_cm_name,
-        #         namespace=executing_namespace,
-        #         body=client.V1DeleteOptions()
-        #     )
-        #     logger.info(f"ConfigMap {params_cm_name} deleted successfully")
-        # except client.exceptions.ApiException as e:
-        #     logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
+        # Delete the ConfigMap
+        try:
+            v1.delete_namespaced_config_map(
+                name=params_cm_name,
+                namespace=executing_namespace,
+                body=client.V1DeleteOptions()
+            )
+            logger.info(f"ConfigMap {params_cm_name} deleted successfully")
+        except client.exceptions.ApiException as e:
+            logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
 
-        # # Delete cwl-workflow configmap
-        # cwl_cm_name = f"cwl-workflow-{job_id}"
+        # Delete cwl-workflow configmap
+        cwl_cm_name = f"cwl-workflow-{job_id}"
 
-        # # Delete the ConfigMap
-        # try:
-        #     v1.delete_namespaced_config_map(
-        #         name=cwl_cm_name,
-        #         namespace=executing_namespace,
-        #         body=client.V1DeleteOptions()
-        #     )
-        #     logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
-        # except client.exceptions.ApiException as e:
-        #     logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
+        # Delete the ConfigMap
+        try:
+            v1.delete_namespaced_config_map(
+                name=cwl_cm_name,
+                namespace=executing_namespace,
+                body=client.V1DeleteOptions()
+            )
+            logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
+        except client.exceptions.ApiException as e:
+            logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
 
 
         if exit_status == zoo.SERVICE_SUCCEEDED:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -524,6 +524,22 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
 
         exit_status = runner.execute()
 
+        # Remove params configmaps
+        job_id = conf["lenv"]["usid"]
+        params_cm_name = f"params-{job_id}"
+
+        try:
+            custom_api.delete_namespaced_custom_object(
+                group="core.telespazio-uk.io",
+                version="v1alpha1",
+                namespace=executing_namespace,
+                plural="configmaps",
+                name=params_cm_name,
+            )
+        except Exception as e:
+            logger.error(f"Error in deleting params configmap: {e}")
+
+
         if exit_status == zoo.SERVICE_SUCCEEDED:
             logger.info(f"Setting Collection into output key {list(outputs.keys())[0]}")
             outputs[list(outputs.keys())[0]]["value"] = execution_handler.feature_collection

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -535,10 +535,10 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
 
         # Delete the ConfigMap
         try:
-            v1.delete_namespaced_configmap(
-                name=params_cm_name,
-                namespace=executing_namespace,
-            )
+            # v1.delete_namespaced_configmap(
+            #     name=params_cm_name,
+            #     namespace=executing_namespace,
+            # )
             logger.info(f"ConfigMap {params_cm_name} deleted successfully")
         except client.exceptions.ApiException as e:
             logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -534,14 +534,14 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         params_cm_name = f"params-{job_id}"
 
         # Delete the ConfigMap
-        try:
+        # try:
             # v1.delete_namespaced_configmap(
             #     name=params_cm_name,
             #     namespace=executing_namespace,
             # )
-            logger.info(f"ConfigMap {params_cm_name} deleted successfully")
-        except client.exceptions.ApiException as e:
-            logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
+        #     logger.info(f"ConfigMap {params_cm_name} deleted successfully")
+        # except client.exceptions.ApiException as e:
+        #     logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
 
         # # Delete cwl-workflow configmap
         # cwl_cm_name = f"cwl-workflow-{job_id}"

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -535,9 +535,10 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
 
         # Delete the ConfigMap
         try:
-            v1.delete_namespaced_configmap(
+            v1.delete_namespaced_config_map(
                 name=params_cm_name,
                 namespace=executing_namespace,
+                body=client.V1DeleteOptions()
             )
             logger.info(f"ConfigMap {params_cm_name} deleted successfully")
         except client.exceptions.ApiException as e:
@@ -548,9 +549,10 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
 
         # Delete the ConfigMap
         try:
-            v1.delete_namespaced_configmap(
+            v1.delete_namespaced_config_map(
                 name=cwl_cm_name,
                 namespace=executing_namespace,
+                body=client.V1DeleteOptions()
             )
             logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
         except client.exceptions.ApiException as e:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -202,7 +202,6 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
 
             lenv = self.conf.get("lenv", {})
             self.conf["additional_parameters"]["job_id"] = lenv.get("usid", "")
-            logger.info(f"Job ID was set to {self.conf['additional_parameters']['job_id']}")
             self.conf["additional_parameters"]["process"] = output_prefix
             self.conf["additional_parameters"]["CALLING_WORKSPACE"] = self.calling_workspace_name
             self.conf["additional_parameters"]["EXECUTING_WORKSPACE"] = self.executing_workspace_name
@@ -495,8 +494,6 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         # Disable the service account, use basic which has no access permissions, forcing to use AWS credentials volume
         conf.setdefault("eodhp", {})
         conf["eodhp"]["serviceAccountName"] = "default"
-
-        logger.info(f"CONF IS NOW {conf}")
 
         execution_handler = EoepcaCalrissianRunnerExecutionHandler(conf=conf, inputs=inputs)
 

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -202,6 +202,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
 
             lenv = self.conf.get("lenv", {})
             self.conf["additional_parameters"]["job_id"] = lenv.get("usid", "")
+            logger.info(f"Job ID was set to {self.conf['additional_parameters']['job_id']}")
             self.conf["additional_parameters"]["process"] = output_prefix
             self.conf["additional_parameters"]["CALLING_WORKSPACE"] = self.calling_workspace_name
             self.conf["additional_parameters"]["EXECUTING_WORKSPACE"] = self.executing_workspace_name

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -533,30 +533,30 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         # Delete params configmap
         params_cm_name = f"params-{job_id}"
 
-        # Delete the ConfigMap
-        try:
-            v1.delete_namespaced_config_map(
-                name=params_cm_name,
-                namespace=executing_namespace,
-                body=client.V1DeleteOptions()
-            )
-            logger.info(f"ConfigMap {params_cm_name} deleted successfully")
-        except client.exceptions.ApiException as e:
-            logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
+        # # Delete the ConfigMap
+        # try:
+        #     v1.delete_namespaced_config_map(
+        #         name=params_cm_name,
+        #         namespace=executing_namespace,
+        #         body=client.V1DeleteOptions()
+        #     )
+        #     logger.info(f"ConfigMap {params_cm_name} deleted successfully")
+        # except client.exceptions.ApiException as e:
+        #     logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
 
-        # Delete cwl-workflow configmap
-        cwl_cm_name = f"cwl-workflow-{job_id}"
+        # # Delete cwl-workflow configmap
+        # cwl_cm_name = f"cwl-workflow-{job_id}"
 
-        # Delete the ConfigMap
-        try:
-            v1.delete_namespaced_config_map(
-                name=cwl_cm_name,
-                namespace=executing_namespace,
-                body=client.V1DeleteOptions()
-            )
-            logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
-        except client.exceptions.ApiException as e:
-            logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
+        # # Delete the ConfigMap
+        # try:
+        #     v1.delete_namespaced_config_map(
+        #         name=cwl_cm_name,
+        #         namespace=executing_namespace,
+        #         body=client.V1DeleteOptions()
+        #     )
+        #     logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
+        # except client.exceptions.ApiException as e:
+        #     logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
 
 
         if exit_status == zoo.SERVICE_SUCCEEDED:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -525,36 +525,36 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         exit_status = runner.execute()
 
         # Set job_id
-        # job_id = conf["lenv"]["usid"]
+        job_id = conf["lenv"]["usid"]
 
-        # # Create a CoreV1Api client instance
-        # v1 = client.CoreV1Api()
+        # Create a CoreV1Api client instance
+        v1 = client.CoreV1Api()
 
-        # # Delete params configmap
-        # params_cm_name = f"params-{job_id}"
+        # Delete params configmap
+        params_cm_name = f"params-{job_id}"
 
         # Delete the ConfigMap
-        # try:
-            # v1.delete_namespaced_configmap(
-            #     name=params_cm_name,
-            #     namespace=executing_namespace,
-            # )
-        #     logger.info(f"ConfigMap {params_cm_name} deleted successfully")
-        # except client.exceptions.ApiException as e:
-        #     logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
+        try:
+            v1.delete_namespaced_configmap(
+                name=params_cm_name,
+                namespace=executing_namespace,
+            )
+            logger.info(f"ConfigMap {params_cm_name} deleted successfully")
+        except client.exceptions.ApiException as e:
+            logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
 
-        # # Delete cwl-workflow configmap
-        # cwl_cm_name = f"cwl-workflow-{job_id}"
+        # Delete cwl-workflow configmap
+        cwl_cm_name = f"cwl-workflow-{job_id}"
 
-        # # Delete the ConfigMap
-        # try:
-        #     v1.delete_namespaced_configmap(
-        #         name=cwl_cm_name,
-        #         namespace=executing_namespace,
-        #     )
-        #     logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
-        # except client.exceptions.ApiException as e:
-        #     logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
+        # Delete the ConfigMap
+        try:
+            v1.delete_namespaced_configmap(
+                name=cwl_cm_name,
+                namespace=executing_namespace,
+            )
+            logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
+        except client.exceptions.ApiException as e:
+            logger.error(f"Exception when deleting ConfigMap {cwl_cm_name}: {e}")
 
 
         if exit_status == zoo.SERVICE_SUCCEEDED:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -528,21 +528,20 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         job_id = conf["lenv"]["usid"]
 
         # Create a CoreV1Api client instance
-        # v1 = client.CoreV1Api()
+        v1 = client.CoreV1Api()
 
-        # # Delete params configmap
-        # params_cm_name = f"params-{job_id}"
+        # Delete params configmap
+        params_cm_name = f"params-{job_id}"
 
-        # # Delete the ConfigMap
-        # try:
-        #     v1.delete_namespaced_configmap(
-        #         name=params_cm_name,
-        #         namespace=executing_namespace,
-        #         body=client.V1DeleteOptions(),
-        #     )
-        #     logger.info(f"ConfigMap {params_cm_name} deleted successfully")
-        # except client.exceptions.ApiException as e:
-        #     logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
+        # Delete the ConfigMap
+        try:
+            v1.delete_namespaced_configmap(
+                name=params_cm_name,
+                namespace=executing_namespace,
+            )
+            logger.info(f"ConfigMap {params_cm_name} deleted successfully")
+        except client.exceptions.ApiException as e:
+            logger.error(f"Exception when deleting ConfigMap {params_cm_name}: {e}")
 
         # # Delete cwl-workflow configmap
         # cwl_cm_name = f"cwl-workflow-{job_id}"
@@ -552,7 +551,6 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
         #     v1.delete_namespaced_configmap(
         #         name=cwl_cm_name,
         #         namespace=executing_namespace,
-        #         body=client.V1DeleteOptions(),
         #     )
         #     logger.info(f"ConfigMap {cwl_cm_name} deleted successfully")
         # except client.exceptions.ApiException as e:


### PR DESCRIPTION
## Delete Left Over ConfigMaps
- We now use job-specific configmaps for cwl workflow details and parameters
- These are no longer needed once the workflow is completed
- Delete these configmaps upon workflow completion