### PR TITLE
Feature/eodhp 1254 no longer rename collection

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -247,6 +247,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             collection = None
             try:
                 collection = next(cat.get_all_collections())
+                collection_id = collection.id
                 logger.info("Got collection from outputs")
             except:
                 try:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -244,7 +244,6 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 logger.error(f"Exception: {e}")
 
             job_id = self.conf["additional_parameters"]["job_id"]
-            logger.info(f"Create collection with ID col_{job_id}")
             collection = None
             try:
                 collection = next(cat.get_all_collections())
@@ -252,6 +251,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             except:
                 try:
                     logger.info("No collection found in outputs, creating from items")
+                    collection_id = "collection" # some default ID
                     items=cat.get_all_items()
                     itemFinal=[]
                     for i in items:
@@ -263,7 +263,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                             cDict["storage:region"]=self.conf["additional_parameters"]["STAGEOUT_AWS_REGION"]
                             cDict["storage:endpoint"]=self.conf["additional_parameters"]["STAGEOUT_AWS_SERVICEURL"]
                             i.assets[a]=i.assets[a].from_dict(cDict)
-                        i.collection_id=f"col_{job_id}"
+                        i.collection_id=collection_id
                         itemFinal+=[i.clone()]
                     collection = ItemCollection(items=itemFinal)
                     logger.info("Created collection from items")
@@ -277,7 +277,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 return
 
             collection_dict=collection.to_dict()
-            collection_dict["id"]=f"col_{job_id}"
+            collection_dict["id"]=collection_id
 
             # Update links with HTTPS links
             workspace_domain = self.conf["additional_parameters"]["WORKSPACE_DOMAIN"]


### PR DESCRIPTION
## Set Collection ID to Default Value
- We no longer use catalog and collection IDs generated from the `job_id` of an execution
- Instead just set this to be a default collection ID of `collection`
- This collection is only used temporarily to return output items, and is not uploaded to S3