### PR TITLE
Update requirements to use new org repos

### DIFF
--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -21,8 +21,8 @@ dependencies:
   - kubernetes-node
   - kubernetes-server
   - pip:
-    - git+https://github.com/UKEODHP/zoo-calrissian-runner.git@main
-    - git+https://github.com/UKEODHP/pycalrissian.git@main
+    - git+https://github.com/EO-DataHub/zoo-calrissian-runner.git@main
+    - git+https://github.com/EO-DataHub/pycalrissian.git@main
     - attrs
     - cwl-utils==0.14
     - kubernetes==28.1.0


### PR DESCRIPTION
Update requirements to use EO-DataHub org repos now the code has been transfered.